### PR TITLE
Fix styling issues on small screens

### DIFF
--- a/docs/stylesheets/styles.css
+++ b/docs/stylesheets/styles.css
@@ -566,9 +566,10 @@ strong {
 }
 
 .wrapper {
-  width: 600px;
-  margin: 0 auto;
+  width: 1000px;
+  margin: 0 -400px 0 auto;
   position: relative;
+  right: 50%;
 }
 
 section img {
@@ -793,12 +794,10 @@ header p {
 }
 
 section {
-  width: 1000px;
   padding: 30px 30px 50px 30px;
   margin: 20px 0;
   margin-top: 190px;
 position: relative;
-	left: -400px;
   background: #fbfbfb;
   -moz-border-radius: 3px;
   -webkit-border-radius: 3px;
@@ -862,6 +861,12 @@ footer {
   line-height: 16px;
 }
 
+@media print, screen and (max-width: 1200px) {
+  div.wrapper {
+    margin: 0 auto;
+    right: auto;
+  }
+}
 @media print, screen and (max-width: 1060px) {
   div.wrapper {
     width: auto;


### PR DESCRIPTION
On screens smaller than 1200px, not all content can be viewed. This is because of a `left: -400px;` style in `section`.

The fix is to move the `400px` style to `.wrapper` and to have it trigger only when the screen size is larger than `1200px`.

---

**400px screen:**

Before:

<img width="512" alt="old-400px" src="https://user-images.githubusercontent.com/3039310/49030905-97cc8c80-f176-11e8-98dd-eb3db11e5330.png">

After:

<img width="512" alt="new-400px" src="https://user-images.githubusercontent.com/3039310/49030920-a0bd5e00-f176-11e8-9a0a-0f98fa9a452b.png">

---

**1070px screen:**

Before:

<img width="1182" alt="old-1070px" src="https://user-images.githubusercontent.com/3039310/49030929-a9159900-f176-11e8-8d0c-f4688102b065.png">

After:

<img width="1182" alt="new-1070px" src="https://user-images.githubusercontent.com/3039310/49030939-ad41b680-f176-11e8-9290-24d8607044ea.png">

---

**1350px screen:**

Before:

<img width="1462" alt="old-1350px" src="https://user-images.githubusercontent.com/3039310/49030960-b599f180-f176-11e8-9c81-85a47c631807.png">

After:

<img width="1462" alt="new-1350px" src="https://user-images.githubusercontent.com/3039310/49030965-b894e200-f176-11e8-80c6-a723296ef85d.png">


